### PR TITLE
Update getting-started.mdx to reference correct CSS path

### DIFF
--- a/data/themes/docs/overview/getting-started.mdx
+++ b/data/themes/docs/overview/getting-started.mdx
@@ -45,7 +45,7 @@ Install the package from your command line.
 Import the global CSS file at the root of your application.
 
 ```ts
-import '@radix-ui/themes/index.css';
+import '@radix-ui/themes/styles.css';
 ```
 
 ### 3. Add the Theme component


### PR DESCRIPTION
The docs were referencing `index.css` but the file is `styles.css`.

This pull request:
- [x] Updates documentation or example code

